### PR TITLE
v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Release History
 
+## v1.2.0 (19-09-15)
+
+### New
+- added template module to git repository
+- down -e/--exclude flag that will exclude given chapters from being downloaded
+- mangakakalot.com module
+
+### Changes
+- mangadex module will now show all groups for a chapter (Group A | Group B | Group C)
+- down -r and -s flags now will decline non-number input
+- removed the Manga.ch_info list, now Manga.chapters gets edited
+- small changes to the filtering functions
+
+### Fixes
+- manga that only has 1 chapter with chapter number 0 will no longer ignore selection
+- fixed images saving as .None when imghdr.what() did not find the file type, the response header will be used in that case
+
 ## v1.1.1 (19-09-10)
 
 ### New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 ### Fixes
 - manga that only has 1 chapter with chapter number 0 will no longer ignore selection
 - fixed images saving as .None when imghdr.what() did not find the file type, the response header will be used in that case
+- heavenmanga_org module exception
+- file extension fix
 
 ## v1.1.1 (19-09-10)
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Currently supports:
 - [mangaseeonline.us](https://mangaseeonline.us/)
 - [mangatown.com](https://www.mangatown.com/)
 - [heavenmanga.org](https://ww2.heavenmanga.org/)
+- [mangakakalot.com](https://mangakakalot.com/page)
 
 
 Allows you to download manga in 5 ways:
@@ -87,6 +88,13 @@ Download the newest chapter (based on chapter number not time of upload):
 ```
 SMD down link_to_manga [more_links] -l
 SMD down link_to_manga [more_links] --latest
+```
+
+Exclude chapters from download (works together with -r and -s):
+
+```
+SMD down link_to_manga [more_links] -e 5 10 1
+SMD down link_to_manga [more_links] --exclude 5 10 1
 ```
 
 Download into a different directory:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ required = [
 
 setuptools.setup(
     name="simple-manga-downloader",
-    version="1.1.1",
+    version="1.2.0",
     author="Kanjirito",
     author_email="kanjirito@protonmail.com",
     license="GPLv3",

--- a/simple_manga_downloader/SMD.py
+++ b/simple_manga_downloader/SMD.py
@@ -1,8 +1,9 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3
 from simple_manga_downloader.modules.mangadex_org import Mangadex
 from simple_manga_downloader.modules.mangaseeonline_us import Mangasee
 from simple_manga_downloader.modules.mangatown_com import Mangatown
 from simple_manga_downloader.modules.heavenmanga_org import Heavenmanga
+from simple_manga_downloader.modules.mangakakalot_com import Mangakakalot
 from simple_manga_downloader.modules.config_parser import Config
 from pathlib import Path
 import argparse
@@ -43,6 +44,8 @@ def site_detect(link, title_return=False, directory=None):
         Manga = Heavenmanga(link, directory)
     elif "mangatown.com" in link:
         Manga = Mangatown(link, directory)
+    elif "mangakakalot.com" in link:
+        Manga = Mangakakalot(link, directory)
     else:
         print(f"Wrong link: \"{link}\"")
         return False
@@ -78,14 +81,21 @@ def parser():
                              dest="custom_dire",
                              default=None,
                              help="Custom path for manga download")
+    parser_down.add_argument("-e", "--exclude",
+                             help="Chapters to exclude \"1 5 10 15\"",
+                             nargs="+",
+                             type=float,
+                             default=[])
     group = parser_down.add_mutually_exclusive_group()
     group.add_argument("-r", "--range",
                        help="Accepts two chapter numbers,"
                        "both ends are inclusive. \"1 15\"",
-                       nargs=2)
+                       nargs=2,
+                       type=float)
     group.add_argument("-s", "--selection",
                        help="Accepts multiple chapters \"2 10 25\"",
-                       nargs="+")
+                       nargs="+",
+                       type=float)
     group.add_argument("-l", "--latest",
                        action='store_true')
 
@@ -208,8 +218,8 @@ def update_mode():
                   "\n------------------------")
             chapter_info_get(Manga)
             print()
-            total_num_ch += len(Manga.ch_info)
-            found_titles[Manga.series_title] = [ch for ch in Manga.ch_info]
+            total_num_ch += len(Manga.chapters)
+            found_titles[Manga.series_title] = [ch for ch in Manga.chapters]
 
     print("------------------------\nChecking complete!\n")
     if not total_num_ch:
@@ -220,7 +230,7 @@ def update_mode():
     for title, chapter in found_titles.items():
         print(f"{title} - {len(chapter)} chapter(s):")
         for ch in chapter:
-            print(f"    {ch['name']}")
+            print(f"    Chapter {ch}")
     print(f"{total_num_ch} chapter(s) ready to download")
     confirm = input(f"Start the download? "
                     "[y to confirm/anything else to cancel]: ").lower()
@@ -241,71 +251,67 @@ def filter_wanted(Manga, ignore=False):
 
     chapter_list = list(Manga.chapters)
     chapter_list.sort()
-    Manga.chapters = {k: Manga.chapters[k] for k in chapter_list}
 
     if ignore:
         wanted = (ch for ch in chapter_list)
     else:
-        wanted = filter_selection(Manga, chapter_list)
+        wanted = filter_selection(chapter_list)
 
-    filtered = filter_downloaded(Manga, wanted)
+    filtered = filter_downloaded(Manga.manga_dir, wanted)
 
     print("\n------------------------\n"
           f"Found {len(filtered)} wanted chapter(s) for {Manga.series_title}"
           "\n------------------------")
-    for ch in list(Manga.chapters):
-        if ch not in filtered:
-            del Manga.chapters[ch]
+
+    Manga.chapters = {k: Manga.chapters[k] for k in filtered}
     if Manga.site == "mangadex.org":
         Manga.check_groups()
 
 
-def filter_selection(Manga, chapter_list):
+def filter_selection(chapter_list):
     '''A generator that yields wanted chapters based on selection'''
-    if len(Manga.chapters) == 1 and not chapter_list[0]:
-        for ch in chapter_list:
-            yield ch
-    elif ARGS.latest:
+
+    if ARGS.latest:
         yield max(chapter_list)
-    elif ARGS.range is not None:
-        a = float(ARGS.range[0])
-        b = float(ARGS.range[1])
+    elif ARGS.range:
+        a = ARGS.range[0]
+        b = ARGS.range[1]
         for ch in chapter_list:
-            if a <= ch <= b:
+            if a <= ch <= b and ch not in ARGS.exclude:
                 yield ch
-    elif ARGS.selection is not None:
+    elif ARGS.selection:
         for n in ARGS.selection:
-            n = float(n)
             if n.is_integer():
                 n = int(n)
-            if n in chapter_list:
+            if n in chapter_list and n not in ARGS.exclude:
                 yield n
     else:
         for ch in chapter_list:
-            yield ch
+            if ch not in ARGS.exclude:
+                yield ch
 
 
-def filter_downloaded(Manga, wanted):
+def filter_downloaded(manga_dir, wanted):
     '''Filters the "filtered" based on what is already downloaded'''
-    if not Manga.manga_dir.is_dir():
+    if not manga_dir.is_dir():
         filtered = list(wanted)
     else:
         filtered = []
         for n in wanted:
             chapter_name = f"Chapter {n}"
-            if chapter_name not in os.listdir(Manga.manga_dir):
+            if chapter_name not in os.listdir(manga_dir):
                 filtered.append(n)
     return filtered
 
 
 def chapter_info_get(Manga):
     '''Calls the get_info() of the manga objects'''
-    Manga.ch_info = []
-    for ch in Manga.chapters:
+    for ch in list(Manga.chapters):
         print(f"Checking: Chapter {ch}")
         status = Manga.get_info(ch)
         if status is not True:
-            print(f"\nSomething went wrong! \n{status}")
+            del Manga.chapters[ch]
+            print(status)
 
 
 def downloader(manga_objects):
@@ -319,26 +325,31 @@ def downloader(manga_objects):
             pass
 
         # Goes ever every chapter
-        for ch in Manga.ch_info:
-            print(f"\nDownloading {Manga.series_title} - {ch['name']}"
+        for ch in Manga.chapters.items():
+            chapter_name = f"Chapter {ch[0]}"
+
+            print(f"\nDownloading {Manga.series_title} - {chapter_name}"
                   "\n------------------------")
 
-            ch_dir = Manga.manga_dir / ch["name"]
+            ch_dir = Manga.manga_dir / chapter_name
             ch_dir.mkdir()
 
             # Goes over every page using a generator
-            page_info = page_gen(Manga, ch)
+            page_info = page_gen(Manga, ch, chapter_name)
             for image_name, link in page_info:
 
                 image = download(link, Manga.scraper)
                 if not image:
                     print("Failed to get image, skipping to next chapter")
-                    failed_text = f"{Manga.series_title} - {ch['name']}"
+                    failed_text = f"{Manga.series_title} - {chapter_name}"
                     download.failed.append(failed_text)
                     break
 
                 file_type = imghdr.what("", h=image.content)
+                if not file_type:
+                    file_type = image.headers["Content-Type"].split("/")[1]
                 full_image_name = f"{image_name}.{file_type}"
+
                 with open(ch_dir / full_image_name, "wb") as f:
                     for chunk in image.iter_content(1024):
                         f.write(chunk)
@@ -395,14 +406,14 @@ def download_info_print():
             print(f)
 
 
-def page_gen(Manga, ch):
+def page_gen(Manga, ch, chapter_name):
     '''A generator that yields a tuple with the page name and link'''
-    for n, link in enumerate(ch["pages"]):
-        base_name = f"{Manga.series_title} - {ch['name']} -"
+    for n, link in enumerate(ch[1]["pages"]):
+        base_name = f"{Manga.series_title} - {chapter_name} -"
         page_string = f"Page {n}"
 
-        if ch["title"]:
-            title = f"{html.unescape(ch['title'])} -"
+        if ch[1]["title"]:
+            title = f"{html.unescape(ch[1]['title'])} -"
             image_name = " ".join([base_name, title, page_string])
         else:
             image_name = " ".join([base_name, page_string])

--- a/simple_manga_downloader/SMD.py
+++ b/simple_manga_downloader/SMD.py
@@ -347,7 +347,8 @@ def downloader(manga_objects):
 
                 file_type = imghdr.what("", h=image.content)
                 if not file_type:
-                    file_type = image.headers["Content-Type"].split("/")[1]
+                    header = image.headers["Content-Type"]
+                    file_type = header.split("/")[1].split(";")[0]
                 full_image_name = f"{image_name}.{file_type}"
 
                 with open(ch_dir / full_image_name, "wb") as f:

--- a/simple_manga_downloader/modules/heavenmanga_org.py
+++ b/simple_manga_downloader/modules/heavenmanga_org.py
@@ -89,7 +89,7 @@ class Heavenmanga:
         # Getting the first one to check if they work
         try:
             test = requests.get(pages[0], stream=True, timeout=5)
-        except requests.ConnectionError:
+        except (requests.ConnectionError, requests.Timeout):
             return f"Chapter is probably broken\n{link}\n"
         if not test:
             return f"Chapter is probably broken\n{link}\n"

--- a/simple_manga_downloader/modules/heavenmanga_org.py
+++ b/simple_manga_downloader/modules/heavenmanga_org.py
@@ -67,8 +67,7 @@ class Heavenmanga:
             except ValueError:
                 ch_num = float(num)
 
-            self.chapters[ch_num] = {"name": f"Chapter {ch_num}",
-                                     "link": chapter_link,
+            self.chapters[ch_num] = {"link": chapter_link,
                                      "title": None}
         return True
 
@@ -84,18 +83,16 @@ class Heavenmanga:
 
         soup = BeautifulSoup(r.text, "html.parser")
         viewer = soup.find("center")
-        image_links = [img["src"] for img in viewer.find_all("img")]
+        pages = [img["src"] for img in viewer.find_all("img")]
 
         # The site has sometimes broken chapters
         # Getting the first one to check if they work
         try:
-            test = requests.get(image_links[0], stream=True, timeout=5)
+            test = requests.get(pages[0], stream=True, timeout=5)
         except requests.ConnectionError:
             return f"Chapter is proably broken\n{link}\n"
         if not test:
             return f"Chapter is proably broken\n{link}\n"
 
-        self.ch_info.append({"name": self.chapters[ch]["name"],
-                             "title": self.chapters[ch]["title"],
-                             "pages": image_links})
+        self.chapters[ch]["pages"] = pages
         return True

--- a/simple_manga_downloader/modules/heavenmanga_org.py
+++ b/simple_manga_downloader/modules/heavenmanga_org.py
@@ -90,9 +90,9 @@ class Heavenmanga:
         try:
             test = requests.get(pages[0], stream=True, timeout=5)
         except requests.ConnectionError:
-            return f"Chapter is proably broken\n{link}\n"
+            return f"Chapter is probably broken\n{link}\n"
         if not test:
-            return f"Chapter is proably broken\n{link}\n"
+            return f"Chapter is probably broken\n{link}\n"
 
         self.chapters[ch]["pages"] = pages
         return True

--- a/simple_manga_downloader/modules/mangadex_org.py
+++ b/simple_manga_downloader/modules/mangadex_org.py
@@ -53,7 +53,7 @@ class Mangadex():
 
             # Creates the number of the chapter
             # Uses chapter number if present
-            # Sets to 1 if oneshot
+            # Sets to 0 if oneshot
             # Slices title if "Chapter XX"
             if ch["chapter"]:
                 num = float(ch["chapter"])
@@ -63,13 +63,21 @@ class Mangadex():
                 num = float(ch["chapter"].split()[-1])
             else:
                 num = 0.0
-
             if num.is_integer():
                 num = int(num)
 
+            all_groups = []
+            if ch["group_name"]:
+                all_groups.append(ch["group_name"])
+            if ch["group_name_2"]:
+                all_groups.append(ch["group_name_2"])
+            if ch["group_name_3"]:
+                all_groups.append(ch["group_name_3"])
+
+            all_groups_str = " | ".join(all_groups)
             self.chapters.setdefault(num, {})
-            self.chapters[num][ch["group_name"]] = ch
-            self.chapters[num][ch["group_name"]]["ch_id"] = chapter
+            self.chapters[num][all_groups_str] = {"ch_id": chapter,
+                                                  "title": ch["title"]}
         return True
 
     def check_groups(self):
@@ -109,7 +117,6 @@ class Mangadex():
 
     def get_info(self, ch):
         '''Gets the data about the specific chapters using the mangadex API'''
-        # The list used by the download function
 
         ch_id = self.chapters[ch]["ch_id"]
         try:
@@ -123,8 +130,7 @@ class Mangadex():
         data = r.json()
         # Skips chapter if the release is delayed
         if data["status"] == "delayed":
-            print("\tChapter is a delayed release, ignoring it")
-            return True
+            return "\tChapter is a delayed release, ignoring it"
 
         # Fixes the incomplete link
         if data["server"] == "/data/":
@@ -134,8 +140,6 @@ class Mangadex():
 
         url = f"{server}{data['hash']}/"
         pages = [f"{url}{page}" for page in data['page_array']]
+        self.chapters[ch]["pages"] = pages
 
-        self.ch_info.append({"pages": pages,
-                             "name": f"Chapter {ch}",
-                             "title": data["title"]})
         return True

--- a/simple_manga_downloader/modules/mangatown_com.py
+++ b/simple_manga_downloader/modules/mangatown_com.py
@@ -51,8 +51,7 @@ class Mangatown():
             except ValueError:
                 ch_num = float(num)
 
-            self.chapters[ch_num] = {"name": f"Chapter {ch_num}",
-                                     "link": chapter_link,
+            self.chapters[ch_num] = {"link": chapter_link,
                                      "title": chapter_title}
         return True
 
@@ -83,7 +82,5 @@ class Mangatown():
             image_links.append(img_link)
 
         # Saves the needed data
-        self.ch_info.append({"name": self.chapters[ch]["name"],
-                             "title": self.chapters[ch]["title"],
-                             "pages": image_links})
+        self.chapters[ch]["pages"] = image_links
         return True

--- a/template/module_template.py
+++ b/template/module_template.py
@@ -1,14 +1,20 @@
+# Cloud flare
+import cfscrape
+import requests.exceptions
+
+# No cloudflare
 import requests
+
 from bs4 import BeautifulSoup
 
 
-class Mangasee():
+class ClassName:
     def __init__(self, link, directory):
         self.scraper = None
-        self.site = "mangaseeonline.us"
+        self.site = "site.com"
         self.folder = directory
         self.manga_link = link
-        self.base_link = "https://mangaseeonline.us"
+        self.base_link = "https://site.com"
 
     def get_chapters(self, title_return):
         '''Gets the list of available chapters
@@ -24,21 +30,22 @@ class Mangasee():
 
         soup = BeautifulSoup(r.text, "html.parser")
 
-        self.series_title = soup.find(class_="SeriesName").string
+        self.series_title = "find title"
+        self.manga_dir = self.folder / self.series_title
         if title_return:
             return True
-        self.manga_dir = self.folder / self.series_title
 
-        chapters = soup.find_all(class_="list-group-item")
+        found_chapters = "finding all chapter links in the soup"
 
         self.chapters = {}
-        for chapter in chapters:
-            num = chapter["chapter"]
+        for chapter in found_chapters:
+
+            num = "finding chapter number in soup"
             try:
                 num = int(num)
             except ValueError:
                 num = float(num)
-            link = chapter["href"].replace("-page-1", "")
+            link = "finding chapter link in soup"
 
             self.chapters[num] = {"link": link,
                                   "title": None}
@@ -46,18 +53,17 @@ class Mangasee():
 
     def get_info(self, ch):
         '''Gets the needed data abut the chapters from the site'''
-
-        pages_link = f"{self.base_link}{self.chapters[ch]['link']}"
+        link = self.chapters[ch]["link"]
         try:
-            r = requests.get(pages_link, timeout=5)
+            r = requests.get(link, timeout=5)
         except requests.Timeout:
             return "Request Timeout"
         if r.status_code != 200:
             return r.status_code
+
         soup = BeautifulSoup(r.text, "html.parser")
 
-        img_containers = soup.find_all(class_="fullchapimage")
-        pages = [div.contents[0]["src"] for div in img_containers]
+        pages = ["list of found image links"]
 
         self.chapters[ch]["pages"] = pages
         return True


### PR DESCRIPTION
### New
- added template module to git repository
- down -e/--exclude flag that will exclude given chapters from being downloaded
- mangakakalot.com module

### Changes
- mangadex module will now show all groups for a chapter (Group A | Group B | Group C)
- down -r and -s flags now will decline non-number input
- removed the Manga.ch_info list, now Manga.chapters gets edited
- small changes to the filtering functions

### Fixes
- manga that only has 1 chapter with chapter number 0 will no longer ignore selection
- fixed images saving as .None when imghdr.what() did not find the file type, the response header will be used in that case
- heavenmanga_org module exception
- file extension fix

