### PR TITLE
v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## v1.4.0(pre-release)
+## v1.4.0(19-10-10)
 
 ## New
 - covers, a new config setting that allows to download the covers for the manga, defaults to false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - covers, a new config setting that allows to download the covers for the manga, defaults to false
 - conf -c/--covers flag to toggle the cover option
 - after download lists what chapters have failed/succeeded
+- invalid input in mangadex multiple groups selection will now skip the chapter instead of forcing a choice
 
 ## Changes
 - every module now uses request sessions
@@ -23,6 +24,7 @@
 - heavenmanga switched to cfscrape and url changed
 - conf -r index errors
 - default download path when using custom config
+- html entities in group names
 
 ## v1.3.0 (19-09-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Release History
 
+## v1.4.0(pre-release)
+
+## New
+- covers, a new config setting that allows to download the covers for the manga, defaults to false
+- conf -c/--covers flag to toggle the cover option
+- after download lists what chapters have failed/succeeded
+
+## Changes
+- every module now uses request sessions
+- changed get_handler() into a decorator
+- modules now use the new exception handler decorator 
+- moved decorators into a separate file
+- conf -c/--clear-tracked had the short flag changed to -t
+- config parser now falls back to defaults if setting is missing
+- changed the download chunk size
+- output changes
+- down and update mode now have the same order of action
+- a lot of code changes/clean-up
+
+## Fixes
+- heavenmanga switched to cfscrape and url changed
+- conf -r index errors
+- default download path when using custom config
+
 ## v1.3.0 (19-09-19)
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ SMD conf -r link_to_manga 5 "sample title" link_to_manga 2
 
 Clearing the tracked list:
 ```
-SMD conf -c
+SMD conf -t
 SMD conf --clear-tracked
 ```
 
@@ -156,6 +156,12 @@ Changing the save directory:
 ```
 SMD conf -s path/to/directory
 SMD conf --save-directory path/to/directory
+```
+
+Toggle the covers setting:
+```
+SMD conf -c
+SMD conf --covers
 ```
 
 Reset the config to the default:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ required = [
 
 setuptools.setup(
     name="simple-manga-downloader",
-    version="1.3.0",
+    version="1.4.0",
     author="Kanjirito",
     author_email="kanjirito@protonmail.com",
     license="GPLv3",

--- a/simple_manga_downloader/SMD.py
+++ b/simple_manga_downloader/SMD.py
@@ -1,40 +1,45 @@
 #!/usr/bin/env python3
-from .modules.mangadex_org import Mangadex
-from .modules.mangaseeonline_us import Mangasee
-from .modules.mangatown_com import Mangatown
-from .modules.heavenmanga_org import Heavenmanga
-from .modules.mangakakalot_com import Mangakakalot
-from .modules.config_parser import Config
+from .modules import Mangadex
+from .modules import Mangasee
+from .modules import Mangatown
+from .modules import Heavenmanga
+from .modules import Mangakakalot
+from .modules import Config
+from .decorators import limiter, request_exception_handler
 from pathlib import Path
 import argparse
-import requests
-import time
 import html
 import os
 import imghdr
-
-ARGS = None
-CONFIG = None
+import time
 
 
 def main():
-    global ARGS
-    global CONFIG
-    ARGS = parser()
-    CONFIG = Config(ARGS.custom_cfg)
-    mode = ARGS.subparser_name
+    args = parser()
+    config = Config(args.custom_cfg)
+    mode = args.subparser_name
     if mode == "down":
-        down_mode()
-    elif mode == "conf":
-        conf_mode()
+        main_pipeline(args.input, args, config)
     elif mode == "update":
-        update_mode()
+        main_pipeline(config.tracked_manga.values(), args, config)
+    elif mode == "conf":
+        conf_mode(args, config)
 
 
-def site_detect(link, title_return=False, directory=None):
-    '''Detects the site and creates a proper manga object'''
-    if directory is None:
-        directory = CONFIG.manga_directory
+def site_detect(link, args, config):
+    '''
+    Detects the site and creates a proper manga object
+    '''
+    try:
+        custom = args.custom_dire
+        if custom:
+            path = custom
+        else:
+            path = config.manga_directory
+    except AttributeError:
+        path = config.manga_directory
+
+    directory = Path(path)
 
     if "mangadex.org" in link:
         site = Mangadex
@@ -51,34 +56,344 @@ def site_detect(link, title_return=False, directory=None):
         return False
 
     Manga = site(link, directory)
-    status = get_handler(Manga.manga_link, Manga.get_chapters, title_return)
-    if status:
-        return Manga
-    else:
-        return False
+
+    return Manga
 
 
-def get_handler(manga_link, func, arg):
+def get_cover(Manga):
     '''
-    Runs the given func with given arg and handles all request exceptions
-    Returns True if nothing failed, prints error and returns False otherwise
+    Gets the cover for given Manga
+    Skips if cover already saved
     '''
     try:
-        status = func(arg)
-    except requests.Timeout:
-        status = "Request Timeout"
-    except requests.ConnectionError:
-        status = "Connection Error"
-    except requests.HTTPError:
-        status = "HTTP code error"
-    except requests.RequestException as e:
-        status = f"A unexpected problem {e}"
+        for file in Manga.manga_dir.iterdir():
+            if Manga.series_title in file.stem:
+                return False
+    except FileNotFoundError:
+        pass
 
-    if status is not True:
-        print(f"\nSomething went wrong! \n{status}\n{manga_link}")
-        return False
+    Manga.manga_dir.mkdir(parents=True, exist_ok=True)
+    no_ext = Manga.manga_dir / Manga.series_title
+
+    return download_image(Manga.cover_url, Manga.session, no_ext)
+
+
+def conf_mode(args, config):
+    if args.default:
+        config.reset_config()
+    elif args.clear_tracked:
+        config.clear_tracked()
+
+    if args.add:
+        for link in args.add:
+            print()
+            Manga = site_detect(link, args, config)
+            if Manga is False:
+                continue
+            title = Manga.get_chapters(title_return=True)
+            if title is True:
+                config.add_tracked(Manga)
+            else:
+                print(f"{title} for:\n{link}")
+    elif args.remove:
+        config.remove_tracked(args.remove)
+    if args.list:
+        config.list_tracked(args.verbose)
+    if args.m_dir:
+        config.change_dir(args.m_dir)
+    if args.position:
+        config.change_position(args.verbose)
+    if args.paths:
+        config.print_paths()
+    if args.cover:
+        config.toogle_covers()
+
+    if config.modified:
+        config.save_config()
+
+
+def main_pipeline(links, args, config):
+    '''
+    Takes a list of manga links and does all of the required stuff
+    '''
+    if not links:
+        print("\nNo manga tracked!")
+        return
+
+    print("\n------------------------\n"
+          f"    Getting {len(links)} manga"
+          "\n------------------------")
+
+    ready = []
+    total_num_ch = 0
+    found_titles = {}
+    for link in links:
+        Manga = site_detect(link, args, config)
+        if not Manga:
+            continue
+
+        status = handle_manga(Manga, config.covers, args)
+        if status:
+            ready.append(Manga)
+            total_num_ch += len(Manga.chapters)
+            found_titles[Manga.series_title] = [ch for ch in Manga.chapters]
+        else:
+            continue
+    print("\n-----------------------------\n"
+          "All manga checking complete!"
+          "\n-----------------------------\n")
+    if not ready:
+        print("Found 0 chapters ready to download.")
+        return
+
+    print(f"Chapters to download:")
+    for title, chapter in found_titles.items():
+        print(f"{title} - {len(chapter)} chapter(s):")
+        for ch in chapter:
+            print(f"    Chapter {ch}")
+
+    print(f"\n{total_num_ch} chapter(s) ready to download")
+    confirm = input(f"Start the download? "
+                    "[y to confirm/anything else to cancel]: "
+                    ).lower()
+    if confirm == "y":
+        downloader(ready)
     else:
-        return True
+        print("Aborting!")
+
+
+def handle_manga(Manga, covers, args):
+    '''
+    Handles all stuff related to the Manga
+    returns True if everything fine
+    '''
+    ch_status = Manga.get_chapters()
+    if ch_status is not True:
+        print("\nSomething went wrong!"
+              f"\n{ch_status}\n{Manga.manga_link}")
+        return False
+
+    message = f"Checking \"{Manga.series_title}\""
+    line_break = make_line(message)
+    print(f"\n{line_break}\n{message}\n{line_break}\n")
+
+    if covers and Manga.cover_url:
+        cov = get_cover(Manga)
+        if cov is True:
+            print("-----------\n"
+                  "Cover saved"
+                  "\n-----------\n")
+        elif cov:
+            cov_line = make_line(cov)
+            print(f"{cov_line}\n"
+                  "Failed to get cover"
+                  f"\n{cov}"
+                  f"\n{cov_line}\n")
+    filter_wanted(Manga, args)
+
+    if not Manga.chapters:
+        return False
+
+    message2 = f"Getting info about {len(Manga.chapters)} wanted chapter(s)"
+    line_break2 = make_line(message2)
+    print(f"{message2}\n{line_break2}")
+    chapter_info_get(Manga)
+    return True
+
+
+def filter_wanted(Manga, args):
+    '''
+    Filters the chapters dict to match the criteria
+    '''
+
+    chapter_list = list(Manga.chapters)
+    chapter_list.sort()
+
+    if args.subparser_name == "update":
+        wanted = (ch for ch in chapter_list)
+    else:
+        wanted = filter_selection(chapter_list, args)
+
+    filtered = filter_downloaded(Manga.manga_dir, wanted)
+
+    Manga.chapters = {k: Manga.chapters[k] for k in filtered}
+    if Manga.site == "mangadex.org":
+        Manga.check_groups()
+
+
+def make_line(string):
+    return "-" * len(string)
+
+
+def filter_selection(chapter_list, args):
+    '''A generator that yields wanted chapters based on selection'''
+
+    if args.latest:
+        yield max(chapter_list)
+    elif args.range:
+        a = args.range[0]
+        b = args.range[1]
+        for ch in chapter_list:
+            if a <= ch <= b and ch not in args.exclude:
+                yield ch
+    elif args.selection:
+        for n in args.selection:
+            if n.is_integer():
+                n = int(n)
+            if n in chapter_list and n not in args.exclude:
+                yield n
+    else:
+        for ch in chapter_list:
+            if ch not in args.exclude:
+                yield ch
+
+
+def filter_downloaded(manga_dir, wanted):
+    '''Filters the "filtered" based on what is already downloaded'''
+    if not manga_dir.is_dir():
+        filtered = list(wanted)
+    else:
+        filtered = []
+        for n in wanted:
+            chapter_name = f"Chapter {n}"
+            if chapter_name not in os.listdir(manga_dir):
+                filtered.append(n)
+    return filtered
+
+
+def chapter_info_get(Manga):
+    '''Calls the get_info() of the manga objects and handles the exceptions'''
+    for ch in list(Manga.chapters):
+        print(f"    Chapter {ch}")
+        status = Manga.get_info(ch)
+        if status is not True:
+            print(f"{status}")
+            del Manga.chapters[ch]
+            print()
+
+
+def downloader(manga_objects):
+    '''Downloads the images in the proper directories'''
+
+    start_time = time.time()
+    page_total = 0
+    failed = {}
+    success = {}
+
+    for Manga in manga_objects:
+        Manga.manga_dir.mkdir(parents=True, exist_ok=True)
+
+        for ch in Manga.chapters:
+            status = get_chapter(Manga, ch)
+            page_total += status[0]
+
+            to_app = f"    Chapter {ch}"
+            if status[1]:
+                fail_list = failed.setdefault(Manga.series_title, [])
+                fail_list.append(to_app)
+            else:
+                succ_list = success.setdefault(Manga.series_title, [])
+                succ_list.append(to_app)
+
+    total_time = time.time() - start_time
+    download_summary(page_total, failed, success, total_time)
+
+
+@limiter(0.5)
+@request_exception_handler
+def download_image(link, session, no_ext):
+    '''
+    Download function, gets the image from the link, limited by wrapper
+    no_ext = save target Path object with no file extension
+    '''
+    content = session.get(link, stream=True, timeout=5)
+
+    file_type = imghdr.what("", h=content.content)
+    if not file_type:
+        header = content.headers["Content-Type"]
+        file_type = header.split("/")[1].split(";")[0]
+
+    with open(f"{no_ext}.{file_type}", "wb") as f:
+        for chunk in content.iter_content(None):
+            f.write(chunk)
+
+    return True
+
+
+def download_summary(count, failed, success, total_time):
+    '''Prints the summary of the download'''
+    if count:
+        m, s = divmod(round(total_time), 60)
+        if m > 0:
+            timing = f"{m:02}:{s:02}"
+        else:
+            timing = f"{s} second(s)"
+        message = f"Finished downloading {count} pages in {timing}!"
+        line_break = make_line(message)
+        print(f"\n{line_break}\n{message}\n{line_break}")
+
+    if failed:
+        print("\nFailed downloads:")
+        for fail, fail_list in failed.items():
+            print(f"{fail}:")
+            for f in fail_list:
+                print(f)
+    if success:
+        print("\nSuccessfully downloaded:")
+        for win, win_list in success.items():
+            print(f"{win}:")
+            for w in win_list:
+                print(w)
+
+
+def get_chapter(Manga, num):
+    '''
+    Downloads the pages for the given chapter
+    Returns number of downloaded pages and failed bool
+    num = number of the chapter to get
+    '''
+
+    count = 0
+    failed = False
+    title = Manga.series_title
+    chapter_name = f"Chapter {num}"
+    print(f"\nDownloading {title} - {chapter_name}"
+          "\n------------------------")
+
+    ch_dir = Manga.manga_dir / chapter_name
+    ch_dir.mkdir()
+
+    name_gen = page_name_gen(title,
+                             Manga.chapters[num],
+                             chapter_name)
+    for page_name, link in name_gen:
+        no_ext = ch_dir / page_name
+        image = download_image(link, Manga.session, no_ext)
+        if image is not True:
+            print("Failed to get image, skipping to next chapter")
+            failed = True
+            break
+        else:
+            count += 1
+    return (count, failed)
+
+
+def page_name_gen(manga_title, data, chapter_name):
+    '''A generator that yields a tuple with the page name and link'''
+    for n, link in enumerate(data["pages"]):
+        base_name = f"{manga_title} - {chapter_name} -"
+        page_string = f"Page {n}"
+
+        if data["title"]:
+            title = f"{html.unescape(data['title'])} -"
+            image_name = " ".join([base_name, title, page_string])
+        else:
+            image_name = " ".join([base_name, page_string])
+
+        # Replaces a "/" in titles to something usable
+        image_name = image_name.replace("/", "╱")
+        print(f"    {page_string}")
+        yield (image_name, link)
 
 
 def parser():
@@ -132,7 +447,7 @@ def parser():
                              help="Removes manga from tracked",
                              dest="remove",
                              nargs="+")
-    parser_conf.add_argument("-c", "--clear-tracked",
+    parser_conf.add_argument("-t", "--clear-tracked",
                              help="Clears the tracked list",
                              action="store_true")
     parser_conf.add_argument("-s", "--save-directory",
@@ -157,296 +472,13 @@ def parser():
                              help="Print config and manga path",
                              action="store_true",
                              dest="paths")
+    parser_conf.add_argument("-c", "--covers",
+                             help="Toggles the cover download",
+                             action="store_true",
+                             dest="cover")
 
     args = parser.parse_args()
     return args
-
-
-def down_mode():
-    if ARGS.custom_dire:
-        directory = Path(ARGS.custom_dire)
-    else:
-        directory = CONFIG.manga_directory
-
-    manga_objects = []
-    for link in ARGS.input:
-        Manga = site_detect(link, directory=directory)
-        if not Manga:
-            continue
-        filter_wanted(Manga)
-        if Manga.chapters:
-            manga_objects.append(Manga)
-    for Manga in manga_objects:
-        print("\n------------------------\n"
-              f"Getting: {Manga.series_title}"
-              "\n------------------------")
-        chapter_info_get(Manga)
-        downloader([Manga])
-    download_info_print()
-
-
-def conf_mode():
-    if ARGS.default:
-        CONFIG.reset_config()
-    elif ARGS.clear_tracked:
-        CONFIG.clear_tracked()
-
-    if ARGS.add:
-        for link in ARGS.add:
-            Manga = site_detect(link, title_return=True)
-            if Manga is False:
-                continue
-            CONFIG.add_tracked(Manga)
-    elif ARGS.remove:
-        CONFIG.remove_tracked(ARGS.remove)
-    if ARGS.list:
-        CONFIG.list_tracked(ARGS.verbose)
-    if ARGS.m_dir:
-        CONFIG.change_dir(ARGS.m_dir)
-    if ARGS.position:
-        CONFIG.change_position(ARGS.verbose)
-    if ARGS.paths:
-        CONFIG.print_paths()
-
-    # Saves if config was modified
-    if CONFIG.modified:
-        CONFIG.save_config()
-
-
-def update_mode():
-    if not CONFIG.tracked_manga:
-        print("No manga tracked!")
-        return
-    print(f"Updating {len(CONFIG.tracked_manga)} manga")
-    manga_objects = []
-
-    # Gets the main information about the manga
-    for link in CONFIG.tracked_manga.values():
-        Manga = site_detect(link)
-        if not Manga:
-            continue
-        filter_wanted(Manga, ignore=True)
-        if Manga.chapters:
-            manga_objects.append(Manga)
-
-    # Goes over every manga and gets the chapter information
-    # Keeps track of some information
-    total_num_ch = 0
-    found_titles = {}
-    if manga_objects:
-        print("\n------------------------\n"
-              "Getting info about chapters"
-              "\n------------------------\n")
-        for Manga in manga_objects:
-            print(f"Getting chapter info for \"{Manga.series_title}\"",
-                  "\n------------------------")
-            chapter_info_get(Manga)
-            print()
-            total_num_ch += len(Manga.chapters)
-            found_titles[Manga.series_title] = [ch for ch in Manga.chapters]
-
-    print("------------------------\nChecking complete!\n")
-    if not total_num_ch:
-        print("Found 0 chapters ready to download.")
-        return
-
-    print(f"Chapters to download:")
-    for title, chapter in found_titles.items():
-        print(f"{title} - {len(chapter)} chapter(s):")
-        for ch in chapter:
-            print(f"    Chapter {ch}")
-    print(f"{total_num_ch} chapter(s) ready to download")
-    confirm = input(f"Start the download? "
-                    "[y to confirm/anything else to cancel]: ").lower()
-    if confirm == "y":
-        downloader(manga_objects)
-        download_info_print()
-        print("Updated titles:")
-        for title in found_titles:
-            print(f"{title} - {len(found_titles[title])} chapter(s)")
-
-    else:
-        print("Download cancelled")
-
-
-def filter_wanted(Manga, ignore=False):
-    '''Creates a list of chapters that fit the wanted criteria
-    ignore=True skips argument checking, used for update mode'''
-
-    chapter_list = list(Manga.chapters)
-    chapter_list.sort()
-
-    if ignore:
-        wanted = (ch for ch in chapter_list)
-    else:
-        wanted = filter_selection(chapter_list)
-
-    filtered = filter_downloaded(Manga.manga_dir, wanted)
-
-    print("\n------------------------\n"
-          f"Found {len(filtered)} wanted chapter(s) for {Manga.series_title}"
-          "\n------------------------")
-
-    Manga.chapters = {k: Manga.chapters[k] for k in filtered}
-    if Manga.site == "mangadex.org":
-        Manga.check_groups()
-
-
-def filter_selection(chapter_list):
-    '''A generator that yields wanted chapters based on selection'''
-
-    if ARGS.latest:
-        yield max(chapter_list)
-    elif ARGS.range:
-        a = ARGS.range[0]
-        b = ARGS.range[1]
-        for ch in chapter_list:
-            if a <= ch <= b and ch not in ARGS.exclude:
-                yield ch
-    elif ARGS.selection:
-        for n in ARGS.selection:
-            if n.is_integer():
-                n = int(n)
-            if n in chapter_list and n not in ARGS.exclude:
-                yield n
-    else:
-        for ch in chapter_list:
-            if ch not in ARGS.exclude:
-                yield ch
-
-
-def filter_downloaded(manga_dir, wanted):
-    '''Filters the "filtered" based on what is already downloaded'''
-    if not manga_dir.is_dir():
-        filtered = list(wanted)
-    else:
-        filtered = []
-        for n in wanted:
-            chapter_name = f"Chapter {n}"
-            if chapter_name not in os.listdir(manga_dir):
-                filtered.append(n)
-    return filtered
-
-
-def chapter_info_get(Manga):
-    '''Calls the get_info() of the manga objects and handles the exceptions'''
-    for ch in list(Manga.chapters):
-        print(f"Checking: Chapter {ch}")
-        status = get_handler(Manga, Manga.get_info, ch)
-        if not status:
-            del Manga.chapters[ch]
-            print()
-
-
-def downloader(manga_objects):
-    '''Downloads the images in the proper directories'''
-
-    for Manga in manga_objects:
-
-        try:
-            Manga.manga_dir.mkdir(parents=True)
-        except FileExistsError:
-            pass
-
-        # Goes ever every chapter
-        for ch in Manga.chapters.items():
-            chapter_name = f"Chapter {ch[0]}"
-
-            print(f"\nDownloading {Manga.series_title} - {chapter_name}"
-                  "\n------------------------")
-
-            ch_dir = Manga.manga_dir / chapter_name
-            ch_dir.mkdir()
-
-            # Goes over every page using a generator
-            page_info = page_gen(Manga, ch, chapter_name)
-            for image_name, link in page_info:
-
-                image = download(link, Manga.scraper)
-                if not image:
-                    print("Failed to get image, skipping to next chapter")
-                    failed_text = f"{Manga.series_title} - {chapter_name}"
-                    download.failed.append(failed_text)
-                    break
-
-                file_type = imghdr.what("", h=image.content)
-                if not file_type:
-                    header = image.headers["Content-Type"]
-                    file_type = header.split("/")[1].split(";")[0]
-                full_image_name = f"{image_name}.{file_type}"
-
-                with open(ch_dir / full_image_name, "wb") as f:
-                    for chunk in image.iter_content(1024):
-                        f.write(chunk)
-
-
-def counter_timer(func):
-    '''Decorator for the download function that keeps track of stats and
-    times the download'''
-    def wrapper(link, scraper):
-        before = time.time()
-        difference = before - wrapper.last_get_time
-        if difference < 0.5:
-            time.sleep(0.5 - difference)
-        content = func(link, scraper)
-        after = time.time()
-        wrapper.last_get_time = after
-        wrapper.count += 1
-        wrapper.time += after - before
-        return content
-    wrapper.count = 0
-    wrapper.time = 0
-    wrapper.last_get_time = 0
-    wrapper.failed = []
-    return wrapper
-
-
-@counter_timer
-def download(link, scraper):
-    '''Download function, gets the image from the link, limited by wrapper'''
-    try:
-        if scraper:
-            content = scraper.get(link, stream=True, timeout=5)
-        else:
-            content = requests.get(link, stream=True, timeout=5)
-    except requests.Timeout:
-        return False
-    return content
-
-
-def download_info_print():
-    '''Prints the summary of the download'''
-    if download.count:
-        m, s = divmod(round(download.time), 60)
-        if m > 0:
-            timing = f"{m:02}:{s:02}"
-        else:
-            timing = f"{s} second(s)"
-        print("\n------------------------\n"
-              f"Finished downloading {download.count} pages in {timing}!"
-              "\n------------------------")
-    if download.failed:
-        print("\nFailed downloads:")
-        for f in download.failed:
-            print(f)
-
-
-def page_gen(Manga, ch, chapter_name):
-    '''A generator that yields a tuple with the page name and link'''
-    for n, link in enumerate(ch[1]["pages"]):
-        base_name = f"{Manga.series_title} - {chapter_name} -"
-        page_string = f"Page {n}"
-
-        if ch[1]["title"]:
-            title = f"{html.unescape(ch[1]['title'])} -"
-            image_name = " ".join([base_name, title, page_string])
-        else:
-            image_name = " ".join([base_name, page_string])
-
-        # Replaces a "/" in titles to something usable
-        image_name = image_name.replace("/", "╱")
-        print(f"Page {n}")
-        yield (image_name, link)
 
 
 if __name__ == '__main__':

--- a/simple_manga_downloader/SMD.py
+++ b/simple_manga_downloader/SMD.py
@@ -192,6 +192,7 @@ def handle_manga(Manga, covers, args):
     filter_wanted(Manga, args)
 
     if not Manga.chapters:
+        print("Found 0 wanted chapters")
         return False
 
     message2 = f"Getting info about {len(Manga.chapters)} wanted chapter(s)"
@@ -217,8 +218,6 @@ def filter_wanted(Manga, args):
     filtered = filter_downloaded(Manga.manga_dir, wanted)
 
     Manga.chapters = {k: Manga.chapters[k] for k in filtered}
-    if Manga.site == "mangadex.org":
-        Manga.check_groups()
 
 
 def make_line(string):

--- a/simple_manga_downloader/decorators.py
+++ b/simple_manga_downloader/decorators.py
@@ -1,0 +1,51 @@
+import requests
+import time
+from functools import wraps
+
+
+def limiter(seconds):
+    '''
+    Limits the decorated func to be called after given amount of seconds
+    '''
+    def middle(func):
+
+        last_called = 0
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            nonlocal last_called
+
+            before = time.time()
+            difference = before - last_called
+            if difference < seconds:
+                time.sleep(seconds - difference)
+
+            result = func(*args, **kwargs)
+
+            last_called = time.time()
+            return result
+        return wrapper
+    return middle
+
+
+def request_exception_handler(func):
+    '''
+    Decorator that handles any request exceptions
+    Returns True func result if nothing failed otherwise a error string
+    '''
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            status = func(*args, **kwargs)
+        except requests.Timeout:
+            status = "Request Timeout"
+        except requests.ConnectionError:
+            status = "Connection Error"
+        except requests.HTTPError:
+            status = "HTTP code error"
+        except requests.RequestException as e:
+            status = f"A unexpected problem {e}"
+
+        return status
+
+    return wrapper

--- a/simple_manga_downloader/modules/__init__.py
+++ b/simple_manga_downloader/modules/__init__.py
@@ -1,0 +1,6 @@
+from .mangadex_org import Mangadex
+from .mangaseeonline_us import Mangasee
+from .mangatown_com import Mangatown
+from .heavenmanga_org import Heavenmanga
+from .mangakakalot_com import Mangakakalot
+from .config_parser import Config

--- a/simple_manga_downloader/modules/mangaseeonline_us.py
+++ b/simple_manga_downloader/modules/mangaseeonline_us.py
@@ -1,27 +1,33 @@
 import requests
+from ..decorators import request_exception_handler
 from bs4 import BeautifulSoup
 
 
 class Mangasee():
     def __init__(self, link, directory):
-        self.scraper = None
+        self.session = requests.Session()
         self.site = "mangaseeonline.us"
         self.folder = directory
         self.manga_link = link
         self.base_link = "https://mangaseeonline.us"
+        self.cover_url = None
 
-    def get_chapters(self, title_return):
+    @request_exception_handler
+    def get_chapters(self, title_return=False):
         '''Gets the list of available chapters
         title_return=True will not create the chapters dict,
         used if only title is needed'''
 
-        r = requests.get(self.manga_link, timeout=5)
+        r = self.session.get(self.manga_link, timeout=5)
         r.raise_for_status()
         soup = BeautifulSoup(r.text, "html.parser")
 
         self.series_title = soup.find(class_="SeriesName").string
         if title_return:
             return True
+        thumb = soup.find(class_="leftImage")
+        if thumb:
+            self.cover_url = thumb.img["src"]
         self.manga_dir = self.folder / self.series_title
 
         chapters = soup.find_all(class_="list-group-item")
@@ -39,12 +45,13 @@ class Mangasee():
                                   "title": None}
         return True
 
+    @request_exception_handler
     def get_info(self, ch):
         '''Gets the needed data abut the chapters from the site'''
 
         pages_link = f"{self.base_link}{self.chapters[ch]['link']}"
 
-        r = requests.get(pages_link, timeout=5)
+        r = self.session.get(pages_link, timeout=5)
         r.raise_for_status()
         soup = BeautifulSoup(r.text, "html.parser")
 

--- a/simple_manga_downloader/modules/mangatown_com.py
+++ b/simple_manga_downloader/modules/mangatown_com.py
@@ -1,28 +1,34 @@
 import requests
 from bs4 import BeautifulSoup
+from ..decorators import request_exception_handler
 import re
 
 
 class Mangatown():
     def __init__(self, link, directory):
-        self.scraper = None
+        self.session = requests.Session()
         self.site = "mangatown.com"
         self.folder = directory
         self.manga_link = link
         self.base_link = "https://www.mangatown.com/"
+        self.cover_url = None
 
-    def get_chapters(self, title_return):
+    @request_exception_handler
+    def get_chapters(self, title_return=False):
         '''Gets the list of available chapters
         title_return=True will not create the chapters dict,
         used if only title is needed'''
 
-        r = requests.get(self.manga_link, timeout=5)
+        r = self.session.get(self.manga_link, timeout=5)
         r.raise_for_status()
         soup = BeautifulSoup(r.text, "html.parser")
 
         self.series_title = soup.find(class_="title-top").string
         if title_return:
             return True
+        thumb = soup.find(class_="detail_info")
+        if thumb:
+            self.cover_url = thumb.img["src"]
         self.manga_dir = self.folder / self.series_title
 
         chapters_soup = soup.find(class_="chapter_list").find_all("li")
@@ -50,10 +56,11 @@ class Mangatown():
                                      "title": chapter_title}
         return True
 
+    @request_exception_handler
     def get_info(self, ch):
         '''Gets the needed data abut the chapters from the site'''
 
-        r = requests.get(self.chapters[ch]["link"], timeout=5)
+        r = self.session.get(self.chapters[ch]["link"], timeout=5)
         r.raise_for_status()
         soup = BeautifulSoup(r.text, "html.parser")
 
@@ -62,7 +69,7 @@ class Mangatown():
 
         image_links = []
         for page in pages:
-            page_r = requests.get(page, timeout=5)
+            page_r = self.session.get(page, timeout=5)
             page_r.raise_for_status()
             page_soup = BeautifulSoup(page_r.text, "html.parser")
             img_link = page_soup.find(id="image")["src"]

--- a/template/module_template.py
+++ b/template/module_template.py
@@ -1,29 +1,34 @@
 # Cloud flare
-import cfscrape
-import requests.exceptions
+# import cfscrape
+# import requests.exceptions
 
 # No cloudflare
 import requests
 
 from bs4 import BeautifulSoup
+from ..decorators import request_exception_handler
 
 
 class ClassName:
     def __init__(self, link, directory):
-        self.scraper = None
+        self.session = requests.Session()
         self.site = "site.com"
         self.folder = directory
         self.manga_link = link
         self.base_link = "https://site.com"
+        self.cover_url = None
 
-    def get_chapters(self, title_return):
+    @request_exception_handler
+    def get_chapters(self, title_return=False):
         '''Gets the list of available chapters
         title_return=True will not create the chapters dict,
         used if only title is needed'''
 
-        r = requests.get(self.manga_link, timeout=5)
+        r = self.session.get(self.manga_link, timeout=5)
         r.raise_for_status()
         soup = BeautifulSoup(r.text, "html.parser")
+
+        self.cover_url = "get cover here"
 
         self.series_title = "find title"
         self.manga_dir = self.folder / self.series_title
@@ -46,11 +51,12 @@ class ClassName:
                                   "title": None}
         return True
 
+    @request_exception_handler
     def get_info(self, ch):
         '''Gets the needed data abut the chapters from the site'''
         link = self.chapters[ch]["link"]
 
-        r = requests.get(link, timeout=5)
+        r = self.session.get(link, timeout=5)
         r.raise_for_status()
         soup = BeautifulSoup(r.text, "html.parser")
 


### PR DESCRIPTION
## New
- covers, a new config setting that allows to download the covers for the manga, defaults to false
- conf -c/--covers flag to toggle the cover option
- after download lists what chapters have failed/succeeded
- invalid input in mangadex multiple groups selection will now skip the chapter instead of forcing a choice

## Changes
- every module now uses request sessions
- changed get_handler() into a decorator
- modules now use the new exception handler decorator 
- moved decorators into a separate file
- conf -c/--clear-tracked had the short flag changed to -t
- config parser now falls back to defaults if setting is missing
- changed the download chunk size
- output changes
- down and update mode now have the same order of action
- a lot of code changes/clean-up

## Fixes
- heavenmanga switched to cfscrape and url changed
- conf -r index errors
- default download path when using custom config
- html entities in group names