### PR TITLE
v1.5.0 PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Release History
 
-## v1.5.0(pre-release)
+## v1.5.0(19-11-15)
 
-## Changes
+## New
 - down -n/--name flag, downloads the given manga using a custom name
 - if a mangadex chapter has no chapter number the downloader will ask for one
+
+## Changes
 - divided get\_chapters() into 2 methods (get\_main() and get\_chapters()) so that the downloader first prints what manga it's working on and then actually does the work (this will allow better handling of edge cases like the mangadex one listed above)
 - added \_\_len\_\_() and \_\_bool\_\_() to manga classes
 - added manganelo.com url support for the mangakakalot module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - if a mangadex chapter has no chapter number the downloader will ask for one
 - divided get\_chapters() into 2 methods (get\_main() and get\_chapters()) so that the downloader first prints what manga it's working on and then actually does the work (this will allow better handling of edge cases like the mangadex one listed above)
 - added \_\_len\_\_() and \_\_bool\_\_() to manga classes
+- added manganelo.com url support for the mangakakalot module
+
+## Fixes
+- another heavenmanga base url change
 
 ## v1.4.1(19-10-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## v1.5.0(pre-release)
+
+## Changes
+- down -n/--name flag, downloads the given manga using a custom name
+- if a mangadex chapter has no chapter number the downloader will ask for one
+- divided get\_chapters() into 2 methods (get\_main() and get\_chapters()) so that the downloader first prints what manga it's working on and then actually does the work (this will allow better handling of edge cases like the mangadex one listed above)
+- added \_\_len\_\_() and \_\_bool\_\_() to manga classes
+
 ## v1.4.1(19-10-29)
 
 ## Changes

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ SMD down link_to_manga -n Some new name
 SMD down link_to_manga --name Some new name
 ```
 **Warning:**
-*Using a custom name when downloading multiple manga at once will cause overwriting of the files*
+*Using a custom name when downloading multiple manga at once will cause overwriting of the files since all of them will be assigned the same name*
 
 ## Update mode
 This mode will go over every manga tracked in the config and download every missing chapter

--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ Download into a different directory:
 SMD down link_to_manga -d "some/path"
 ```
 
+Download using a custom name:
+```
+SMD down link_to_manga -n Some new name
+SMD down link_to_manga --name Some new name
+```
+**Warning:**
+*Using a custom name when downloading multiple manga at once will cause overwriting of the files*
+
 ## Update mode
 This mode will go over every manga tracked in the config and download every missing chapter
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ required = [
 
 setuptools.setup(
     name="simple-manga-downloader",
-    version="1.4.1",
+    version="1.5.0",
     author="Kanjirito",
     author_email="kanjirito@protonmail.com",
     license="GPLv3",

--- a/simple_manga_downloader/SMD.py
+++ b/simple_manga_downloader/SMD.py
@@ -90,7 +90,7 @@ def conf_mode(args, config):
             Manga = site_detect(link, args, config)
             if Manga is False:
                 continue
-            title = Manga.get_chapters(title_return=True)
+            title = Manga.get_main(title_return=True)
             if title is True:
                 config.add_tracked(Manga)
             else:
@@ -135,7 +135,7 @@ def main_pipeline(links, args, config):
         status = handle_manga(Manga, config.covers, args)
         if status:
             ready.append(Manga)
-            total_num_ch += len(Manga.chapters)
+            total_num_ch += len(Manga)
             found_titles[Manga.series_title] = [ch for ch in Manga.chapters]
         else:
             continue
@@ -167,12 +167,14 @@ def handle_manga(Manga, covers, args):
     Handles all stuff related to the Manga
     returns True if everything fine
     '''
-    ch_status = Manga.get_chapters()
-    if ch_status is not True:
+    main_status = Manga.get_main()
+    if main_status is not True:
         print("\nSomething went wrong!"
-              f"\n{ch_status}\n{Manga.manga_link}")
+              f"\n{main_status}\n{Manga.manga_link}")
         return False
 
+    if hasattr(args, "name") and args.name:
+        Manga.series_title = " ".join(args.name)
     message = f"Checking \"{Manga.series_title}\""
     line_break = make_line(message)
     print(f"\n{line_break}\n{message}\n{line_break}\n")
@@ -189,13 +191,14 @@ def handle_manga(Manga, covers, args):
                   "Failed to get cover"
                   f"\n{cov}"
                   f"\n{cov_line}\n")
+    Manga.get_chapters()
     filter_wanted(Manga, args)
 
     if not Manga.chapters:
         print("Found 0 wanted chapters")
         return False
 
-    message2 = f"Getting info about {len(Manga.chapters)} wanted chapter(s)"
+    message2 = f"Getting info about {len(Manga)} wanted chapter(s)"
     line_break2 = make_line(message2)
     print(f"{message2}\n{line_break2}")
     return chapter_info_get(Manga)
@@ -408,9 +411,11 @@ def parser():
     subparsers = parser.add_subparsers(dest="subparser_name",
                                        required=True)
     parser_conf = subparsers.add_parser("conf",
-                                        help="Program will be in the config edit mode")
+                                        help=("Program will be in "
+                                              "the config edit mode"))
     parser_down = subparsers.add_parser("down",
-                                        help="Program will be in the download mode")
+                                        help=("Program will be in "
+                                              "the download mode"))
     subparsers.add_parser("update",
                           help="Program will be in the update mode")
 
@@ -425,6 +430,12 @@ def parser():
                              nargs="+",
                              type=float,
                              default=[])
+    parser_down.add_argument("-n", "--name",
+                             default=None,
+                             nargs="+",
+                             help=("Download the manga with a custom name. "
+                                   "Not recommended to use with multiple "
+                                   "downloads at once."))
     group = parser_down.add_mutually_exclusive_group()
     group.add_argument("-r", "--range",
                        help="Accepts two chapter numbers,"

--- a/simple_manga_downloader/SMD.py
+++ b/simple_manga_downloader/SMD.py
@@ -49,10 +49,12 @@ def site_detect(link, args, config):
         site = Heavenmanga
     elif "mangatown.com" in link:
         site = Mangatown
-    elif "mangakakalot.com" in link:
+    elif "mangakakalot.com" in link or "manganelo.com" in link:
         site = Mangakakalot
     else:
-        print(f"Wrong link: \"{link}\"")
+        msg = f"Wrong link: \"{link}\""
+        line = make_line(msg)
+        print(f"\n{line}\n{msg}\n{line}")
         return False
 
     Manga = site(link, directory)
@@ -223,6 +225,9 @@ def filter_wanted(Manga, args):
 
 
 def make_line(string):
+    '''
+    Returns a string of "-" with the same length as the given string
+    '''
     return "-" * len(string)
 
 

--- a/simple_manga_downloader/modules/heavenmanga_org.py
+++ b/simple_manga_downloader/modules/heavenmanga_org.py
@@ -12,13 +12,24 @@ class Heavenmanga:
         self.manga_link = link
         self.base_link = "https://ww4.heavenmanga.org/"
         self.cover_url = None
+        self.chapters = {}
+
+    @property
+    def manga_dir(self):
+        return self.folder / self.series_title
+
+    def __bool__(self):
+        return True
+
+    def __len__(self):
+        return len(self.chapters)
 
     @request_exception_handler
-    def get_chapters(self, title_return=False):
-        '''Gets the list of available chapters
-        title_return=True will not create the chapters dict,
-        used if only title is needed'''
-
+    def get_main(self, title_return=False):
+        '''
+        Gets the main manga info like title, cover url and chapter links
+        title_return=True will only get the title and return
+        '''
         r = self.session.get(self.manga_link, timeout=5)
         r.raise_for_status()
         soup = BeautifulSoup(r.text, "html.parser")
@@ -26,7 +37,6 @@ class Heavenmanga:
         self.series_title = soup.find(class_="name bigger").string
         if title_return:
             return True
-        self.manga_dir = self.folder / self.series_title
         thumb = soup.find(alt="Cover Image")
         if thumb:
             self.cover_url = thumb["src"]
@@ -47,8 +57,14 @@ class Heavenmanga:
             soup = BeautifulSoup(page.text, "html.parser")
             chapter_divs += soup.find_all(class_="two-rows go-border")
 
-        self.chapters = {}
-        for chapter in chapter_divs:
+        self.data = chapter_divs
+        return True
+
+    def get_chapters(self):
+        '''
+        Handles the chapter data by assigning chapter numbers
+        '''
+        for chapter in self.data:
             a_div = chapter.find("a")
             chapter_link = a_div["href"]
 

--- a/simple_manga_downloader/modules/heavenmanga_org.py
+++ b/simple_manga_downloader/modules/heavenmanga_org.py
@@ -10,7 +10,7 @@ class Heavenmanga:
         self.site = "heavenmanga.org"
         self.folder = directory
         self.manga_link = link
-        self.base_link = "https://ww4.heavenmanga.org/"
+        self.base_link = "https://ww5.heavenmanga.org/"
         self.cover_url = None
         self.chapters = {}
 

--- a/simple_manga_downloader/modules/mangaseeonline_us.py
+++ b/simple_manga_downloader/modules/mangaseeonline_us.py
@@ -11,13 +11,24 @@ class Mangasee():
         self.manga_link = link
         self.base_link = "https://mangaseeonline.us"
         self.cover_url = None
+        self.chapters = {}
+
+    @property
+    def manga_dir(self):
+        return self.folder / self.series_title
+
+    def __bool__(self):
+        return True
+
+    def __len__(self):
+        return len(self.chapters)
 
     @request_exception_handler
-    def get_chapters(self, title_return=False):
-        '''Gets the list of available chapters
-        title_return=True will not create the chapters dict,
-        used if only title is needed'''
-
+    def get_main(self, title_return=False):
+        '''
+        Gets the main manga info like title, cover url and chapter links
+        title_return=True will only get the title and return
+        '''
         r = self.session.get(self.manga_link, timeout=5)
         r.raise_for_status()
         soup = BeautifulSoup(r.text, "html.parser")
@@ -28,12 +39,16 @@ class Mangasee():
         thumb = soup.find(class_="leftImage")
         if thumb:
             self.cover_url = thumb.img["src"]
-        self.manga_dir = self.folder / self.series_title
 
-        chapters = soup.find_all(class_="list-group-item")
+        self.data = soup.find_all(class_="list-group-item")
+        return True
 
-        self.chapters = {}
-        for chapter in chapters:
+    def get_chapters(self):
+        '''
+        Handles the chapter data by assigning chapter numbers
+        '''
+
+        for chapter in self.data:
             num = chapter["chapter"]
             try:
                 num = int(num)

--- a/template/module_template.py
+++ b/template/module_template.py
@@ -17,13 +17,24 @@ class ClassName:
         self.manga_link = link
         self.base_link = "https://site.com"
         self.cover_url = None
+        self.chapters = {}
+
+    @property
+    def manga_dir(self):
+        return self.folder / self.series_title
+
+    def __bool__(self):
+        return True
+
+    def __len__(self):
+        return len(self.chapters)
 
     @request_exception_handler
-    def get_chapters(self, title_return=False):
-        '''Gets the list of available chapters
-        title_return=True will not create the chapters dict,
-        used if only title is needed'''
-
+    def get_main(self, title_return=False):
+        '''
+        Gets the main manga info like title, cover url and chapter links
+        title_return=True will only get the title and return
+        '''
         r = self.session.get(self.manga_link, timeout=5)
         r.raise_for_status()
         soup = BeautifulSoup(r.text, "html.parser")
@@ -31,14 +42,17 @@ class ClassName:
         self.cover_url = "get cover here"
 
         self.series_title = "find title"
-        self.manga_dir = self.folder / self.series_title
         if title_return:
             return True
 
-        found_chapters = "finding all chapter links in the soup"
+        self.data = "finding all chapter links in the soup"
+        return True
 
-        self.chapters = {}
-        for chapter in found_chapters:
+    def get_chapters(self):
+        '''
+        Handles the chapter data by assigning chapter numbers
+        '''
+        for chapter in self.data:
 
             num = "finding chapter number in soup"
             try:


### PR DESCRIPTION
## New
- down -n/--name flag, downloads the given manga using a custom name
- if a mangadex chapter has no chapter number the downloader will ask for one

## Changes
- divided get\_chapters() into 2 methods (get\_main() and get\_chapters()) so that the downloader first prints what manga it's working on and then actually does the work (this will allow better handling of edge cases like the mangadex one listed above)
- added \_\_len\_\_() and \_\_bool\_\_() to manga classes
- added manganelo.com url support for the mangakakalot module

## Fixes
- another heavenmanga base url change
